### PR TITLE
v13.1.0.4: prevent taskbar-minimized windows reappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project aims to follow Semanti
 
 Note: The 13.x versions are the reworked Foundry VTT v13+ fork/modernization of the original module.
 
+## [13.1.0.4]
+### Fixed
+- Windows minimized to the taskbar are no longer force-unhidden on render (fixes some sheets reappearing after reload)
+
 ## [13.1.0.3]
 ### Changed
 - Taskbar docking debug output no longer uses console warnings; adds minimal always-on startup/state logs (version + top/bottom/off)

--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
 			"name": "paulcheeba"		}
 	],
 	"description": "Window Taskbar and Window Buttons: Minimize and Pin floating Windows to a top or bottom taskbar. Updated for Foundry VTT v13+.",
-	"version": "13.1.0.3",
+	"version": "13.1.0.4",
 	"compatibility": {
 		"minimum": "13",
 		"verified": "13.351",

--- a/windowcontrols.js
+++ b/windowcontrols.js
@@ -1841,7 +1841,7 @@ class WindowControls {
 
       // Safety: don't permanently hide windows across refresh unless we know why.
       const key = WindowControls._getAppKey(app);
-      if (element?.style?.display === 'none' && (!key || !WindowControls._taskbarEntries.has(String(key)))) {
+      if (element?.style?.display === 'none' && element?.dataset?.wcTaskbarHidden !== '1' && (!key || !WindowControls._taskbarEntries.has(String(key)))) {
         element.style.display = '';
       }
 
@@ -1857,7 +1857,7 @@ class WindowControls {
       void WindowControls._enforceSingleInstanceByPersistentId(app);
 
       const key = WindowControls._getAppKey(app);
-      if (el.style.display === 'none' && (!key || !WindowControls._taskbarEntries.has(String(key)))) {
+      if (el.style.display === 'none' && el?.dataset?.wcTaskbarHidden !== '1' && (!key || !WindowControls._taskbarEntries.has(String(key)))) {
         el.style.display = '';
       }
 


### PR DESCRIPTION
## 13.1.0.4 (Foundry VTT v13+)

This update fixes an edge case where a journal window minimized to the taskbar could reappear after a reload.

### Fixes
- Windows hidden to the taskbar are no longer force-shown during render, improving restore consistency for pinned sheets.